### PR TITLE
Handle simultaneous defeat in battle

### DIFF
--- a/combat.py
+++ b/combat.py
@@ -179,6 +179,13 @@ def battle(team1: List[Character], team2: List[Character]):
         combat_round(team1, team2)
         round_num += 1
 
-    # Announce winning team
-    winner = "Team 1" if any(c.is_alive() for c in team1) else "Team 2"
+    # Check who is still standing after the loop
+    team1_alive = any(c.is_alive() for c in team1)
+    team2_alive = any(c.is_alive() for c in team2)
+
+    if not team1_alive and not team2_alive:
+        winner = "No one"
+    else:
+        winner = "Team 1" if team1_alive else "Team 2"
+
     print(f"\n{winner} wins the battle!")

--- a/test_combat.py
+++ b/test_combat.py
@@ -1,5 +1,6 @@
 
 import unittest
+from unittest.mock import patch
 from combat import Character, Weapon, Armor, battle, distribute_damage, apply_spite
 
 # This test suite verifies functionality of the combat system
@@ -60,6 +61,20 @@ class TestCombatSystem(unittest.TestCase):
         battle(team1, team2)
         self.assertTrue(any(c.is_alive() for c in team1))
         self.assertFalse(any(c.is_alive() for c in team2))
+
+    def test_simultaneous_defeat(self):
+        # When both teams have no living members, no one should win
+        dead1 = Character("Dead1", 10, 10, 10, 10, 0, self.dagger, self.none)
+        dead2 = Character("Dead2", 10, 10, 10, 10, 0, self.dagger, self.none)
+        team1 = [dead1]
+        team2 = [dead2]
+
+        with patch('builtins.print') as mock_print:
+            battle(team1, team2)
+
+        self.assertFalse(any(c.is_alive() for c in team1))
+        self.assertFalse(any(c.is_alive() for c in team2))
+        mock_print.assert_any_call("\nNo one wins the battle!")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- improve `battle` to check both teams after combat loop
- declare no winner if both teams are defeated
- test simultaneous defeat case

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_68523ad3b7f88322a6dec1c795e8e4b6