### PR TITLE
Implement per-round XP

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python tnt_simulator_xp_commented.py
    - Run combat rounds
    - Disengage, continue, or quit
    - View end-of-battle summaries
-   - Grant XP to the winning team
+  - XP is awarded each round based on the difference in attack totals
 
 ---
 

--- a/combat.py
+++ b/combat.py
@@ -137,14 +137,22 @@ def combat_round(team1: List[Character], team2: List[Character]):
     # Higher total wins and deals damage
     if team1_attack > team2_attack:
         distribute_damage(team2, team1_attack - team2_attack)
+        winner = 1
+        diff = team1_attack - team2_attack
     elif team2_attack > team1_attack:
         distribute_damage(team1, team2_attack - team1_attack)
+        winner = 2
+        diff = team2_attack - team1_attack
     else:
         print("It's a draw! No damage dealt.")
+        winner = 0
+        diff = 0
 
     # Apply spite damage to both teams
     apply_spite(team2, team1_spite)
     apply_spite(team1, team2_spite)
+
+    return winner, diff
 
 
 # Split incoming damage evenly among all living characters on a team

--- a/tnt_simulator_xp_commented.py
+++ b/tnt_simulator_xp_commented.py
@@ -87,7 +87,14 @@ def encounter_loop():
         while any(c.is_alive() for c in team1) and any(c.is_alive() for c in team2):
             print(f"\n--- Round {round_num} ---")
             from combat import combat_round  # Import here to ensure it's available
-            combat_round(team1, team2)
+            winner, diff = combat_round(team1, team2)
+
+            # Award XP for the round per Tunnels & Trolls rules
+            if winner == 1:
+                award_xp([c for c in team1 if c.is_alive()], diff)
+            elif winner == 2:
+                award_xp([c for c in team2 if c.is_alive()], diff)
+
             round_num += 1
 
             # Between rounds, offer choices
@@ -108,13 +115,13 @@ def encounter_loop():
         for c in team2:
             print(f"{c.name}: {'Alive' if c.is_alive() else 'Defeated'} (CON: {c.con})")
 
-        # Determine winner and award XP
+        # Determine final winner for information only
         if any(c.is_alive() for c in team1) and not any(c.is_alive() for c in team2):
-            award_xp(team1, 100)
+            print("Team 1 is victorious!")
         elif any(c.is_alive() for c in team2) and not any(c.is_alive() for c in team1):
-            award_xp(team2, 100)
+            print("Team 2 is victorious!")
         else:
-            print("No XP awarded due to disengagement or mutual defeat.")
+            print("The battle ended without a clear winner.")
 
         # Ask user if they want to start another encounter
         again = input("\nStart another encounter? (Y/N): ").strip().upper()


### PR DESCRIPTION
## Summary
- award XP each round based on combat totals instead of a flat 100 at battle end
- show which team won after combat concludes
- document new XP approach in README

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_6852427007f48322984289efd0450d20